### PR TITLE
FIX: linking qtwebkit / Disable gold linker.

### DIFF
--- a/recipes-qt/qt5/qtbase_git.bbappend
+++ b/recipes-qt/qt5/qtbase_git.bbappend
@@ -18,3 +18,5 @@ PACKAGECONFIG = " \
 
 EXTRA_OECONF += "'-I${STAGING_DIR_TARGET}/usr/include/interface/vcos/pthreads/' \
                  '-I${STAGING_DIR_TARGET}/usr/include/interface/vmcs_host/linux/'" 
+
+QT_CONFIG_FLAGS += "-no-use-gold-linker"


### PR DESCRIPTION
There was problem when linking qtwebkit.

Here is some info about the problem  http://stackoverflow.com/questions/38166053/an-error-building-qt-libraries-for-the-raspberry-pi-linking-error